### PR TITLE
Catch_all email address

### DIFF
--- a/src/Bogardo/Mailgun/Mailgun/Message.php
+++ b/src/Bogardo/Mailgun/Mailgun/Message.php
@@ -164,6 +164,12 @@ class Message
 	 */
 	public function addRecipient($type, $email, $name = false)
 	{
+		// Check if there is a catch all address for the current environment,
+		// if so, replace the original address with the testing address
+		if(!empty(Config::get('mailgun::catch_all'))){
+			$email = Config::get('mailgun::catch_all');
+		}
+
 		if ($name) {
 			$recipient = "'{$name}' <{$email}>";
 		} else {

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 return array(
 
@@ -33,7 +33,7 @@ return array(
 	 *
 	 */
 	'domain' => '',
-	
+
 	/**
 	 * Force the from address
 	 *
@@ -41,11 +41,25 @@ return array(
 	 * e-mail clients (Outlook) tend to display the from address incorrectly
 	 * By enabling this setting Mailgun will force the `from` address so the
 	 * from address will be displayed correctly in all e-mail clients.
-	 * 
+	 *
 	 * Warning:
 	 * This parameter is not documented in the Mailgun documentation
 	 * because if enabled, Mailgun is not able to handle soft bounces
 	 *
 	 */
 	'force_from_address' => false,
+
+
+	/**
+	 * Add email address that catches all mail traffic.
+	 * Ment for testing purposes in different environments
+	 * Leave the value empty if it is not applicable
+	 *
+	 * To catch all emails in the testing environment, copy this
+	 * config file to packages/bogardo/mailgun/environmentname/config.php
+	 * and adjust the catch_all mailaddress
+	 *
+	 *
+	 */
+	'catch_all' => '',
 );


### PR DESCRIPTION
While working in my app, I found the need to test the mailgun configuration and package.
So I added a 'catch_all' email address, if this is set (you should use different configs for every environment) every recipient will be replaced by the catch_all emailaddress.

This is a great way to test with realistic data without sending emails that shouldn't be sent.
