### PR TITLE
update to support Mailgun 1.7.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "mailgun/mailgun-php": "1.7"
+        "mailgun/mailgun-php": "1.7.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
mailgun/mailgun-php 1.7.1 now uses guzzle >=3.8, but if you already have guzzle 3.9 installed, it errors out as mailgun/mailgun-php 1.7 only uses guzzle 3.8
