### PR TITLE
Return the Mailgun response

### DIFF
--- a/src/Bogardo/Mailgun/Mailgun.php
+++ b/src/Bogardo/Mailgun/Mailgun.php
@@ -96,7 +96,7 @@ class Mailgun extends MailgunApi
 
 		$this->getMessage($view, $data);
 
-		$this->mailgun()->sendMessage(Config::get('mailgun::domain'), $this->getMessageData(), $this->getAttachmentData());
+		return $this->mailgun()->sendMessage(Config::get('mailgun::domain'), $this->getMessageData(), $this->getAttachmentData());
 	}
 
 	/**


### PR DESCRIPTION
The documentation for the function indicates that the response from the Mailgun API should be returned, but currently the method does not return anything. I've updated the code for `send` to return the result of the call to `sendMessage`