### PR TITLE
use api key on every send

### DIFF
--- a/src/Bogardo/Mailgun/Mailgun.php
+++ b/src/Bogardo/Mailgun/Mailgun.php
@@ -98,7 +98,7 @@ class Mailgun extends MailgunApi
 
 		$this->getMessage($view, $data);
 
-		return $this->mailgun()->sendMessage(Config::get('mailgun::domain'), $this->getMessageData(), $this->getAttachmentData());
+		return $this->mailgun(true, Config::get('mailgun::api_key'))->sendMessage(Config::get('mailgun::domain'), $this->getMessageData(), $this->getAttachmentData());
 	}
 
 	/**


### PR DESCRIPTION
this is a work around if using the validate method right before sending a message

work around for #46 