### PR TITLE
fix mailgun base URI

### DIFF
--- a/config/mailgun.php
+++ b/config/mailgun.php
@@ -7,7 +7,7 @@ return [
      *
      */
     'api' => [
-        'endpoint' => 'api.mailgun.com',
+        'endpoint' => 'api.mailgun.net',
         'version' => 'v3',
         'ssl' => true
     ],


### PR DESCRIPTION
fixed the mailgun base URI.. Should be .net instead of .com 
otherwise cURL error 6 occurs - "could not connect to api.mailgun.com"