### PR TITLE
Allow raw() method to accept rendered HTML and text in an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 coverage_html/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,18 @@
 {
-    "name": "bogardo/mailgun",
+    "name": "markokeeffe/mailgun",
     "description": "Laravel package for sending mail via the Mailgun API",
     "keywords": [
         "mailgun",
         "laravel",
         "mail",
         "email",
-        "bogardo"
     ],
-    "homepage": "https://github.com/Bogardo/Mailgun",
+    "homepage": "https://github.com/markokeeffe/Mailgun",
     "license": "MIT",
     "authors": [
         {
-            "name": "Chris Bogaards",
-            "email": "chris@bogardo.com",
-            "homepage": "http://bogardo.com/"
+            "name": "Mark O'Keeffe",
+            "email": "senshi001@gmail.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "mailgun",
         "laravel",
         "mail",
-        "email",
+        "email"
     ],
     "homepage": "https://github.com/markokeeffe/Mailgun",
     "license": "MIT",

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -173,8 +173,28 @@ class Mailer
      */
     protected function setRawBody($view)
     {
-        $this->message->builder()->setHtmlBody($view);
-        $this->message->builder()->setTextBody(strip_tags($view, '<a>'));
+        // If raw body is a string, set HTML and use strip_tags to generate text content
+        if (is_string($view)) {
+            $this->message->builder()->setHtmlBody($view);
+            $this->message->builder()->setTextBody(strip_tags($view, '<a>'));
+        } elseif (is_array($view) && isset($view[0])) {
+            // Get HTML from first element of view array
+            $this->message->builder()->setHtmlBody($view[0]);
+
+            if (isset($view[1])) {
+                // Get text content if present in second element
+                $this->message->builder()->setTextBody($view[1]);
+            }
+        } elseif (is_array($view)) {
+            // Set HTML content from view array
+            if (isset($view['html'])) {
+                $this->message->builder()->setHtmlBody($view['html']);
+            }
+            // Set text content from view array
+            if (isset($view['text'])) {
+                $this->message->builder()->setTextBody($view['text']);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
It would be extremely useful to be able to provide raw HTML and text content separately.

This fix uses the same concept as the send() method uses to support separate HTML and text view names.