### PR TITLE
Add Laravel 5.5 Support for Package Autodiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install the package via composer
 composer require bogardo/mailgun
 ```
 
-Register the ServiceProvider and (optionally) the Facade
+If using Laravel 5.1 to 5.4, Register the ServiceProvider and (optionally) the Facade
 
 ```php
 // config/app.php
@@ -73,6 +73,12 @@ Next, publish the config file with the following `artisan` command.<br />
 
 ```bash
 php artisan vendor:publish --provider="Bogardo\Mailgun\MailgunServiceProvider" --tag="config"
+```
+
+or if using Laravel 5.5 <br />
+
+```bash
+php artisan vendor:publish
 ```
 
 After publishing, configure the package in `config/mailgun.php`.

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Bogardo\Mailgun\MailgunServiceProvider"
+                "Bogardo\\Mailgun\\MailgunServiceProvider"
             ],
             "aliases": {
-                "Mailgun": "Bogardo\Mailgun\Facades\Mailgun"
+                "Mailgun": "Bogardo\\Mailgun\\Facades\\Mailgun"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,15 @@
         "barryvdh/laravel-ide-helper": "Add accurate autocompletion for Laravel Facades, including the Mailgun facade",
         "php-http/guzzle6-adapter": "Use Guzzle 6 as your Mailgun HTTP client",
         "php-http/guzzle5-adapter": "Use Guzzle 5 as your Mailgun HTTP client"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Bogardo\Mailgun\MailgunServiceProvider"
+            ],
+            "aliases": {
+                "Mailgun": "Bogardo\Mailgun\Facades\Mailgun"
+            }
+        }
     }
 }


### PR DESCRIPTION
The change in composer.json will allow Laravel 5.5 to automatically discover the package removing the need to manually add the Service Provider. Updated installation instructions to cater to this change