### PR TITLE
Update Carbon in Composer to match Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=5.5.9",
         "illuminate/support": "~5.1",
         "mailgun/mailgun-php": "^2.1",
-        "nesbot/carbon": "^1.21",
+        "nesbot/carbon": "^1.26.3 || ^2.0",
         "php-http/message": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
This package is incompatible with new installs of Laravel 5.8 because the version of Carbon it uses is too old. This updated sets the Carbon version to the same that Laravel 5.8 uses and should allow for backwards compatibility with previous versions of Laravel 5.